### PR TITLE
Improve error message on Autotune run without BG-data (#1404)

### DIFF
--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -104,6 +104,7 @@ if (!module.parent) {
         var glucose_data = JSON.parse(fs.readFileSync(glucose_input, 'utf8'));
     } catch (e) {
         console.error("Warning: could not parse "+glucose_input);
+        return console.error("Warning: could not parse "+glucose_input", e);
     }
 
     var carb_data = { };

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -248,7 +248,7 @@ do
             cp profile.pump.json profile.json
             exit
         else
-            die "Could not run oref0-autotune-core autotune.$i.json profile.json profile.pump.json"
+            die "Could not run oref0-autotune-core autotune.$i.json profile.json profile.pump.json. Make sure Nightscout contains BG-values for the selected date range, Autotune(Web) does not work without BG-values. See documentation on the how-to check http://nightscout.github.io/nightscout/reports/#day-to-day ."
         fi
     else
         # Copy tuned profile produced by autotune to profile.json for use with next day of data


### PR DESCRIPTION
* Better error handling for Autotune without BG-data

Prevents technical error on the logging which users of Autotune(Web) see.

* Improve error message on Autotune without BG-data

Informs users on where to start investigation.